### PR TITLE
Staging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV DB_HOST="172.22.5.164" \
     ADMIN_USER=admin \
     ADMIN_PASS=admin
 
-This is no set in deployment.yaml to avoid the base image overwriting what we set in the dockerfile
+#This is no set in deployment.yaml to avoid the base image overwriting what we set in the dockerfile
 #ENV CATALINA_OPTS "-Xms2048m -Xmx2048m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/usr/local/tomcat/logs/gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=10M"
 
 RUN mkdir -p /opt

--- a/search.jsp
+++ b/search.jsp
@@ -148,7 +148,7 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
                                         <div class="result">
-                                            <display:table id="result" name="sessionScope.results" requestURI="/search.do"
+                                            <display:table id="result" name="requestScope.results" requestURI="/search.do"
                                                            pagesize="50" sort="list">
                                                 <display:setProperty
                                                         name="paging.banner.placement">top</display:setProperty>


### PR DESCRIPTION
Only create sessions in the request header when the search comes from the UI search page. Otherwise, store and retrieve the results from the requestHeader. This avoid creating hundreds of unwanted sessions