### PR TITLE
Rst 7974 investigate reopen search

### DIFF
--- a/WEB-INF/src/com/calander/actions/caseDetailAction.java
+++ b/WEB-INF/src/com/calander/actions/caseDetailAction.java
@@ -23,9 +23,11 @@ public class caseDetailAction extends Action {
 
         String case_id = request.getParameter("case_id");
 
+        /*
         if (case_id == null || case_id.trim().isEmpty()) {
             return mapping.findForward("success");
         }
+         */
 
         //getting session object from Hibernate Util class
         SessionFactory factory = (SessionFactory) servlet.getServletContext().getAttribute(HibernatePlugin.KEY_NAME);

--- a/WEB-INF/src/com/calander/actions/caseDetailAction.java
+++ b/WEB-INF/src/com/calander/actions/caseDetailAction.java
@@ -23,11 +23,9 @@ public class caseDetailAction extends Action {
 
         String case_id = request.getParameter("case_id");
 
-        /*
         if (case_id == null || case_id.trim().isEmpty()) {
             return mapping.findForward("success");
         }
-         */
 
         //getting session object from Hibernate Util class
         SessionFactory factory = (SessionFactory) servlet.getServletContext().getAttribute(HibernatePlugin.KEY_NAME);

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -198,16 +198,10 @@ public class searchAction extends Action {
 
     public static boolean isUiRequest(HttpServletRequest request) {
 
-        // Explicit override (future-proof)
-        String mode = request.getParameter("mode");
-
-        LOGGER.info(MessageFormat.format("isUiRequest mode {0}", mode));
-
-        if ("api".equalsIgnoreCase(mode)) return false;
-        if ("ui".equalsIgnoreCase(mode)) return true;
 
         // Accept header (best signal)
         String accept = request.getHeader("Accept");
+        LOGGER.info(MessageFormat.format("isUiRequest mode {0}", accept));
         if (accept != null && accept.contains("application/json")) {
             return false;
         }

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -25,44 +26,122 @@ public class searchAction extends Action {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(searchAction.class);
 
-    public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response)
+    public ActionForward execute(ActionMapping mapping, ActionForm form,
+                                 HttpServletRequest request,
+                                 HttpServletResponse response)
             throws IOException, ServletException, Exception {
 
-
         String searchString = sanitizeSearchInput(request.getParameter("search"));
-        /*
-        if (searchString.isEmpty()) {
-            return mapping.findForward("success");
-        }
-        */
 
-        //getting session object from Hibernate Util class
-        SessionFactory factory = (SessionFactory) servlet.getServletContext().getAttribute(HibernatePlugin.KEY_NAME);
-        Session session = factory.openSession();
+        SessionFactory factory = (SessionFactory) servlet.getServletContext()
+                .getAttribute(HibernatePlugin.KEY_NAME);
 
-        Query query = session.createQuery("from Calander c where lower(c.search_date) like :date or lower(c.case_no) like :case or lower(title1) like :title order by c.case_no");
-        query.setString("date", "%" + searchString + "%");
-        query.setString("case", "%" + searchString + "%");
-        query.setString("title", "%" + searchString + "%");
-
-        List arrResults = query.list();
-
-        LOGGER.info(MessageFormat.format("Returned <{0}> rows for search using string <{1}> on search_date or case_no or title1 ", arrResults.size(), searchString));
-
-        session.clear();
-        session.close();
-
-        if (isUiRequest(request.getHeader("Referer"))) {
-            request.getSession(true).setAttribute("results", arrResults);
-        } else {
-            request.setAttribute("results", arrResults);
-        }
+        Session session = null;
 
         try {
-            return mapping.findForward("success");
+            session = factory.openSession();
+
+            boolean isUi = isUiRequest(request);
+
+            String hql = "from Calander c " +
+                    "where lower(c.search_date) like :search " +
+                    "or lower(c.case_no) like :search " +
+                    "or lower(c.title1) like :search " +
+                    "order by c.case_no";
+
+            Query query = session.createQuery(hql);
+            query.setString("search", "%" + searchString.toLowerCase() + "%");
+            query.setTimeout(5); // safety
+
+            if (isUi) {
+                // 🔵 UI MODE (unchanged behaviour, but capped)
+
+                query.setMaxResults(1000); // IMPORTANT: prevent abuse
+
+                List results = query.list();
+
+                LOGGER.info(MessageFormat.format(
+                        "[UI] Returned <{0}> rows for search <{1}>",
+                        results.size(), searchString
+                ));
+
+                request.getSession(true).setAttribute("results", results);
+
+                return mapping.findForward("success");
+
+            } else {
+                // 🟢 API MODE (stateless pagination)
+
+                int page = getPage(request);
+                int pageSize = getPageSize(request);
+
+                query.setFirstResult((page - 1) * pageSize);
+                query.setMaxResults(pageSize);
+
+                List results = query.list();
+
+                boolean hasNextPage = results.size() == pageSize;
+
+                LOGGER.info(MessageFormat.format(
+                        "[API] Search <{0}> page={1} size={2} returned={3}",
+                        searchString, page, pageSize, results.size()
+                ));
+
+                request.setAttribute("results", results);
+                request.setAttribute("page", page);
+                request.setAttribute("pageSize", pageSize);
+                request.setAttribute("hasNextPage", hasNextPage);
+
+                return mapping.findForward("success");
+            }
+
         } catch (Exception ex) {
-            ex.printStackTrace();
-            throw ex; // or return mapping.findForward("error");
+            LOGGER.error("Search failed", ex);
+            throw ex;
+        } finally {
+            if (session != null) {
+                session.clear();
+                session.close();
+            }
+        }
+    }
+
+    private int getPage(HttpServletRequest request) {
+
+        // Standard param first
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                return Math.max(Integer.parseInt(pageParam), 1);
+            } catch (Exception ignored) {}
+        }
+
+        // DisplayTag fallback (d-xxx-p)
+        Enumeration<?> params = request.getParameterNames();
+        while (params.hasMoreElements()) {
+            String name = (String) params.nextElement();
+            if (name.startsWith("d-") && name.endsWith("-p")) {
+                try {
+                    return Math.max(Integer.parseInt(request.getParameter(name)), 1);
+                } catch (Exception ignored) {}
+            }
+        }
+
+        return 1;
+    }
+
+    private int getPageSize(HttpServletRequest request) {
+
+        String sizeParam = request.getParameter("pageSize");
+
+        int defaultSize = 15;
+        int maxSize = 50;
+
+        try {
+            int size = Integer.parseInt(sizeParam);
+            return Math.min(Math.max(size, 1), maxSize);
+        } catch (Exception e) {
+            return defaultSize;
         }
     }
 
@@ -78,7 +157,24 @@ public class searchAction extends Action {
         return searchString.toLowerCase();
     }
 
-    public static boolean isUiRequest(String referer) {
+    public static boolean isUiRequest(HttpServletRequest request) {
+
+        // Explicit override (future-proof)
+        String mode = request.getParameter("mode");
+        if ("api".equalsIgnoreCase(mode)) return false;
+        if ("ui".equalsIgnoreCase(mode)) return true;
+
+        // Accept header (best signal)
+        String accept = request.getHeader("Accept");
+        if (accept != null && accept.contains("application/json")) {
+            return false;
+        }
+
+        // Default to UI
+        return true;
+    }
+
+    public static boolean isUiRequestOld(String referer) {
         if (referer != null && (referer.contains("casetracker.justice.gov.uk") || referer.contains("localhost")) ) {
             return true;
         }

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -67,6 +67,8 @@ public class searchAction extends Action {
                 ));
 
                 request.getSession(true).setAttribute("results", results);
+                request.getSession(true).setAttribute("isUI", "true");
+
 
                 return mapping.findForward("success");
 
@@ -95,6 +97,7 @@ public class searchAction extends Action {
                 Long totalResults = getTotalCount(session, searchString);
                 int totalPages = (int) Math.ceil((double) totalResults / pageSize);
 
+                request.setAttribute("isUI", "false");
                 request.setAttribute("searchString", searchString);
                 request.setAttribute("totalResults", totalResults);
                 request.setAttribute("results", results);

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -141,7 +141,6 @@ public class searchAction extends Action {
 
         // Standard param first
         String pageParam = request.getParameter("page");
-        LOGGER.info(MessageFormat.format("getPage page={0}", pageParam));
         if (pageParam != null) {
             try {
                 return Math.max(Integer.parseInt(pageParam), 1);
@@ -169,9 +168,6 @@ public class searchAction extends Action {
     private int getPageSize(HttpServletRequest request) {
 
         String sizeParam = request.getParameter("pageSize");
-
-        LOGGER.info(MessageFormat.format("getPageSize size={0}", sizeParam));
-
         int defaultSize = 15;
         int maxSize = 50;
 
@@ -197,7 +193,6 @@ public class searchAction extends Action {
     }
 
     public static boolean isUiRequest(HttpServletRequest request) {
-
 
         // Accept header (best signal)
         String accept = request.getHeader("Accept");

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -95,6 +95,7 @@ public class searchAction extends Action {
                 Long totalResults = getTotalCount(session, searchString);
                 int totalPages = (int) Math.ceil((double) totalResults / pageSize);
 
+                request.setAttribute("searchString", searchString);
                 request.setAttribute("totalResults", totalResults);
                 request.setAttribute("startIndex", startIndex);
                 request.setAttribute("endIndex", endIndex);

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -30,9 +30,11 @@ public class searchAction extends Action {
 
 
         String searchString = sanitizeSearchInput(request.getParameter("search"));
+        /*
         if (searchString.isEmpty()) {
             return mapping.findForward("success");
         }
+        */
 
         //getting session object from Hibernate Util class
         SessionFactory factory = (SessionFactory) servlet.getServletContext().getAttribute(HibernatePlugin.KEY_NAME);

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -97,10 +97,10 @@ public class searchAction extends Action {
 
                 request.setAttribute("searchString", searchString);
                 request.setAttribute("totalResults", totalResults);
-                request.setAttribute("startIndex", startIndex);
-                request.setAttribute("endIndex", endIndex);
-                request.setAttribute("totalPages", totalPages);
                 request.setAttribute("results", results);
+                request.setAttribute("startIndex", Integer.valueOf(startIndex));
+                request.setAttribute("endIndex", Integer.valueOf(endIndex));
+                request.setAttribute("totalPages", Integer.valueOf(totalPages));
                 request.setAttribute("hasNextPage", String.valueOf(hasNextPage));
                 request.setAttribute("page", Integer.valueOf(page));
                 request.setAttribute("pageSize", Integer.valueOf(pageSize));

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -141,10 +141,13 @@ public class searchAction extends Action {
 
         // Standard param first
         String pageParam = request.getParameter("page");
+        LOGGER.info(MessageFormat.format("getPage page={1}", pageParam));
         if (pageParam != null) {
             try {
                 return Math.max(Integer.parseInt(pageParam), 1);
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+                LOGGER.info(MessageFormat.format("getPage Exception {1}", ignored.getMessage()));
+            }
         }
 
         // DisplayTag fallback (d-xxx-p)
@@ -154,7 +157,9 @@ public class searchAction extends Action {
             if (name.startsWith("d-") && name.endsWith("-p")) {
                 try {
                     return Math.max(Integer.parseInt(request.getParameter(name)), 1);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                    LOGGER.info(MessageFormat.format("getPage Exception {1}", ignored.getMessage()));
+                }
             }
         }
 
@@ -165,6 +170,8 @@ public class searchAction extends Action {
 
         String sizeParam = request.getParameter("pageSize");
 
+        LOGGER.info(MessageFormat.format("getPageSize size={1}", sizeParam));
+
         int defaultSize = 15;
         int maxSize = 50;
 
@@ -172,6 +179,7 @@ public class searchAction extends Action {
             int size = Integer.parseInt(sizeParam);
             return Math.min(Math.max(size, 1), maxSize);
         } catch (Exception e) {
+            LOGGER.info(MessageFormat.format("getPageSize Exception {1}", e.getMessage()));
             return defaultSize;
         }
     }

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -100,9 +100,9 @@ public class searchAction extends Action {
                 request.setAttribute("endIndex", endIndex);
                 request.setAttribute("totalPages", totalPages);
                 request.setAttribute("results", results);
-                request.setAttribute("page", page);
-                request.setAttribute("pageSize", pageSize);
                 request.setAttribute("hasNextPage", String.valueOf(hasNextPage));
+                request.setAttribute("page", Integer.valueOf(page));
+                request.setAttribute("pageSize", Integer.valueOf(pageSize));
 
                 return mapping.findForward("success");
             }
@@ -127,9 +127,10 @@ public class searchAction extends Action {
 
         Query countQuery = session.createQuery(hql);
         countQuery.setString("search", "%" + searchString.toLowerCase() + "%");
-        countQuery.setTimeout(5); // safety
+        countQuery.setTimeout(5);
 
-        return (Long) countQuery.uniqueResult();
+        Number result = (Number) countQuery.uniqueResult();
+        return result.longValue();
     }
 
     private int getPage(HttpServletRequest request) {

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -141,12 +141,12 @@ public class searchAction extends Action {
 
         // Standard param first
         String pageParam = request.getParameter("page");
-        LOGGER.info(MessageFormat.format("getPage page={1}", pageParam));
+        LOGGER.info(MessageFormat.format("getPage page={0}", pageParam));
         if (pageParam != null) {
             try {
                 return Math.max(Integer.parseInt(pageParam), 1);
             } catch (Exception ignored) {
-                LOGGER.info(MessageFormat.format("getPage Exception {1}", ignored.getMessage()));
+                LOGGER.info(MessageFormat.format("getPage Exception {0}", ignored.getMessage()));
             }
         }
 
@@ -158,7 +158,7 @@ public class searchAction extends Action {
                 try {
                     return Math.max(Integer.parseInt(request.getParameter(name)), 1);
                 } catch (Exception ignored) {
-                    LOGGER.info(MessageFormat.format("getPage Exception {1}", ignored.getMessage()));
+                    LOGGER.info(MessageFormat.format("getPage Exception {0}", ignored.getMessage()));
                 }
             }
         }
@@ -170,7 +170,7 @@ public class searchAction extends Action {
 
         String sizeParam = request.getParameter("pageSize");
 
-        LOGGER.info(MessageFormat.format("getPageSize size={1}", sizeParam));
+        LOGGER.info(MessageFormat.format("getPageSize size={0}", sizeParam));
 
         int defaultSize = 15;
         int maxSize = 50;
@@ -179,7 +179,7 @@ public class searchAction extends Action {
             int size = Integer.parseInt(sizeParam);
             return Math.min(Math.max(size, 1), maxSize);
         } catch (Exception e) {
-            LOGGER.info(MessageFormat.format("getPageSize Exception {1}", e.getMessage()));
+            LOGGER.info(MessageFormat.format("getPageSize Exception {0}", e.getMessage()));
             return defaultSize;
         }
     }
@@ -200,6 +200,9 @@ public class searchAction extends Action {
 
         // Explicit override (future-proof)
         String mode = request.getParameter("mode");
+
+        LOGGER.info(MessageFormat.format("isUiRequest mode {0}", mode));
+
         if ("api".equalsIgnoreCase(mode)) return false;
         if ("ui".equalsIgnoreCase(mode)) return true;
 

--- a/WEB-INF/src/com/calander/actions/searchAction.java
+++ b/WEB-INF/src/com/calander/actions/searchAction.java
@@ -54,7 +54,8 @@ public class searchAction extends Action {
             query.setTimeout(5); // safety
 
             if (isUi) {
-                // 🔵 UI MODE (unchanged behaviour, but capped)
+
+                // UI mode - restrict query to 1000 results
 
                 query.setMaxResults(1000); // IMPORTANT: prevent abuse
 
@@ -70,8 +71,8 @@ public class searchAction extends Action {
                 return mapping.findForward("success");
 
             } else {
-                // 🟢 API MODE (stateless pagination)
 
+                // Non-ui request now requires paging to support scraping
                 int page = getPage(request);
                 int pageSize = getPageSize(request);
 
@@ -87,10 +88,21 @@ public class searchAction extends Action {
                         searchString, page, pageSize, results.size()
                 ));
 
+
+                int startIndex = (page - 1) * pageSize + 1;
+                int endIndex = startIndex + results.size() - 1;
+
+                Long totalResults = getTotalCount(session, searchString);
+                int totalPages = (int) Math.ceil((double) totalResults / pageSize);
+
+                request.setAttribute("totalResults", totalResults);
+                request.setAttribute("startIndex", startIndex);
+                request.setAttribute("endIndex", endIndex);
+                request.setAttribute("totalPages", totalPages);
                 request.setAttribute("results", results);
                 request.setAttribute("page", page);
                 request.setAttribute("pageSize", pageSize);
-                request.setAttribute("hasNextPage", hasNextPage);
+                request.setAttribute("hasNextPage", String.valueOf(hasNextPage));
 
                 return mapping.findForward("success");
             }
@@ -104,6 +116,20 @@ public class searchAction extends Action {
                 session.close();
             }
         }
+    }
+
+    private Long getTotalCount(Session session, String searchString) {
+
+        String hql = "select count(*) from Calander c " +
+                "where lower(c.search_date) like :search " +
+                "or lower(c.case_no) like :search " +
+                "or lower(c.title1) like :search";
+
+        Query countQuery = session.createQuery(hql);
+        countQuery.setString("search", "%" + searchString.toLowerCase() + "%");
+        countQuery.setTimeout(5); // safety
+
+        return (Long) countQuery.uniqueResult();
     }
 
     private int getPage(HttpServletRequest request) {

--- a/WEB-INF/src/dts/legacy/utils/IpRateLimitFilter.java
+++ b/WEB-INF/src/dts/legacy/utils/IpRateLimitFilter.java
@@ -62,7 +62,7 @@ public class IpRateLimitFilter implements Filter {
         boolean shouldLimit = path.contains("/search.do") || path.contains("/getDetail.do");
          */
 
-        if (!isUiRequest(request.getHeader("Referer"))) {
+        if (!isUiRequest(request)) {
 
             String ip = request.getHeader("X-Forwarded-For");
             if (ip != null && !ip.isEmpty()) {

--- a/WEB-INF/struts-config.xml
+++ b/WEB-INF/struts-config.xml
@@ -39,7 +39,7 @@
 
 	<action path="/search"
 			type="com.calander.actions.searchAction"
-		     parameter="search"
+			parameter="search"
 			scope="request">
 			
 			<forward name="success" path="/search.jsp"></forward>

--- a/WEB-INF/struts-config.xml
+++ b/WEB-INF/struts-config.xml
@@ -40,7 +40,7 @@
 	<action path="/search"
 			type="com.calander.actions.searchAction"
 		     parameter="search"
-			scope="session">
+			scope="request">
 			
 			<forward name="success" path="/search.jsp"></forward>
 	</action>    			

--- a/deploy_kubernetes/preprod/ingress.yaml
+++ b/deploy_kubernetes/preprod/ingress.yaml
@@ -32,7 +32,7 @@ metadata:
       94.192.178.93/32,
       52.167.144.219/32,
       128.77.75.64/26,
-      88.97.207.127/32
+      88.97.206.141/32
     nginx.ingress.kubernetes.io/server-snippet: |
       location @custom_403 {
         return 403 "{\"msg\":\"<br/>Civil Appeal Case Tracker<br/>This is a restricted page. Please contact dts-legacy-apps-support-team@hmcts.net for access<br/>\"}";

--- a/index.jsp
+++ b/index.jsp
@@ -114,7 +114,7 @@
                                 <div class="function next right">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
-                                    <a href="search.jsp?action=nextPage">Next <span class="access">page</span></a>
+                                    <a href="search.jsp">Next <span class="access">page</span></a>
                                     <span class="bl"></span>
                                     <span class="br"></span>
                                 </div>

--- a/search.jsp
+++ b/search.jsp
@@ -148,26 +148,20 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
 
+                                        <%--
                                         <p>
                                         <%
-
-                                        <%--
                                             Long   totalResults = (Long)    request.getAttribute("totalResults");
                                             Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
-                                        --%>
-
-
                                             Integer page        = (Integer) request.getAttribute("page");
                                             Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>
-
-                                        <%--
                                                 Showing results <%= startIndex %> &ndash; <%= endIndex %>
                                                 of <%= totalResults %>
                                                 (page <%= page %> of <%= totalPages %>)
-                                        --%>
                                         </p>
+                                        --%>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -149,7 +149,7 @@
                                         <h2>Search results</h2>
                                         <div class="result">
                                             <display:table id="result" name="requestScope.results" requestURI="/search.do"
-                                                           pagesize="50" sort="list">
+                                                           pagesize="5" sort="list">
                                                 <display:setProperty
                                                         name="paging.banner.placement">top</display:setProperty>
                                                 <display:column property="case_no" title="Case number" paramId="case_id"

--- a/search.jsp
+++ b/search.jsp
@@ -1,24 +1,8 @@
-<%@ page isErrorPage="true" %>
 <%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
 <%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
 <%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
 <%@ taglib uri="/WEB-INF/displaytag.tld" prefix="display" %>
 <%@ page import="java.sql.Date" %>
-
-<%-- FORCE exception output at the VERY beginning --%>
-<%
-    if (exception != null) {
-        out.clear();  // important: clear any partial output
-        response.setContentType("text/plain");
-        out.println("=== EXCEPTION OCCURRED IN SEARCH.JSP ===");
-        out.println("Message: " + exception.getMessage());
-        out.println("Exception type: " + exception.getClass().getName());
-        out.println("\nStack trace:");
-        exception.printStackTrace(new PrintWriter(out));
-        out.flush();
-        return;   // STOP processing the rest of the JSP
-    }
-%>
 
 <?xml version="1.0" encoding="utf-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><!-- InstanceBegin template="/Templates/default.dwt" codeOutsideHTMLIsLocked="false" -->
@@ -77,8 +61,6 @@
     <script language="JavaScript" type="text/javascript" src="js/general.js"></script>
 </head>
 
-
-
 <body>
 <a name="top" id="top"></a>
 <div class="iewrapper">
@@ -102,8 +84,15 @@
                     <div id="Content">
                         <div class="holder">
                             <!-- InstanceBeginEditable name="main" -->
+                            <%
 
+                            // Check if the request has been triggered by the "Next page" link
+                            boolean isNextPageLink="nextPage".equals(request.getParameter("action"));
 
+                            // Clear the search results if it's the "Next page" link
+                            if (isNextPageLink) { request.getSession().removeAttribute("results"); }
+
+                            %>
 
                             <div class="steps">
                                 <h2>Ways to Search</h2>
@@ -151,70 +140,26 @@
                                 </div>
                             </logic:present>
 
-<%--
-                            <!-- Request-scoped results (API/non-UI users) -->
+                            <!-- Request-scoped results (API/bot users) -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
-                                        <p>
-                                            Showing results
-                                            <bean:write name="startIndex" scope="request"/>
-                                            &ndash;
-                                            <bean:write name="endIndex" scope="request"/>
-                                            of
-                                            <bean:write name="totalResults" scope="request"/>
-                                            (page
-                                            <bean:write name="page" scope="request"/>
-                                            of
-                                            <bean:write name="totalPages" scope="request"/>)
-                                        </p>
                                         <div class="result">
-                                            <table class="its" cellspacing="0">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Case number</th>
-                                                        <th>Title</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <logic:iterate id="result" name="results" scope="request">
-                                                        <tr>
-                                                            <td>
-                                                                <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>">
-                                                                    <bean:write name="result" property="case_no"/>
-                                                                </a>
-                                                            </td>
-                                                            <td><bean:write name="result" property="title1"/></td>
-                                                        </tr>
-                                                    </logic:iterate>
-                                                </tbody>
-                                            </table>
+                                            <display:table id="result" name="requestScope.results" requestURI="/search.do"
+                                                           pagesize="50" sort="list">
+                                                <display:setProperty
+                                                        name="paging.banner.placement">top</display:setProperty>
+                                                <display:column property="case_no" title="Case number" paramId="case_id"
+                                                                paramProperty="case_no" href="getDetail.do"/>
+                                                <display:column property="title1" title="Title"/>
+                                            </display:table>
                                         </div>
-
-                                        <!-- Paging controls for non-UI clients -->
-                                        <logic:equal name="hasNextPage" value="true" scope="request">
-                                            <p>
-                                                Next page:
-                                                <bean:define id="nextPage" name="page" scope="request" type="java.lang.Integer"/>
-                                                <% int nextPageNum = ((Integer)request.getAttribute("page")) + 1; %>
-                                                <a href="search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>">
-                                                    search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>
-                                                </a>
-                                            </p>
-                                        </logic:equal>
-
-                                        <logic:equal name="hasNextPage" value="false" scope="request">
-                                            <p>No further pages.</p>
-                                        </logic:equal>
-
                                     </div>
                                 </div>
                             </logic:present>
-
-                            --%>
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -141,6 +141,16 @@
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
                               <logic:present name="startIndex" scope="request">
+
+
+                              <% if (exception != null) { %>
+                                  <h2>Exception occurred:</h2>
+                                  <pre><%= exception.getMessage() %></pre>
+                                  <h3>Stack trace:</h3>
+                                  <pre><% exception.printStackTrace(new java.io.PrintWriter(out)); %></pre>
+                              <% } %>
+
+
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>

--- a/search.jsp
+++ b/search.jsp
@@ -1,3 +1,4 @@
+<%@ page isErrorPage="true" %>
 <%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
 <%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
 <%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
@@ -148,48 +149,46 @@
 
                                         <div class="result">
 
-                                            <!-- Page banner -->
-                                            <span class="pagebanner">
-                                                <bean:write name="totalResults" ignore="true"/> items found, displaying
-                                                <bean:write name="startIndex" ignore="true"/> to
-                                                <bean:write name="endIndex" ignore="true"/>.
-                                            </span>
+                                        <!-- Page banner -->
+                                        <span class="pagebanner">
+                                            <bean:write name="totalResults" ignore="true"/> items found, displaying
+                                            <bean:write name="startIndex" ignore="true"/> to
+                                            <bean:write name="endIndex" ignore="true"/>.
+                                        </span>
 
-                                            <!-- Page links -->
-                                            <span class="pagelinks">
-                                                <%
-                                                    String search = request.getParameter("search");
-                                                    if (search == null) search = "";
+                                        <!-- Page links -->
+                                        <span class="pagelinks">
+                                            <%
+                                                String search = request.getParameter("search");
+                                                if (search == null) search = "";
 
-                                                    // Safe extraction with defaults
-                                                    Integer pageObj = (Integer) request.getAttribute("page");
-                                                    Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
-                                                    String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                                Integer pageObj      = (Integer) request.getAttribute("page");
+                                                Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
+                                                String  hasNextStr   = (String)  request.getAttribute("hasNextPage");
 
-                                                    int page = (pageObj != null) ? pageObj.intValue() : 1;
-                                                    int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
-                                                    boolean hasNext = "true".equalsIgnoreCase(hasNextPage);
-                                                %>
+                                                int pageNum    = (pageObj != null) ? pageObj.intValue() : 1;
+                                                int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
+                                                boolean hasNext = "true".equalsIgnoreCase(hasNextStr);
+                                            %>
 
-                                                <!-- First / Prev -->
-                                                <% if (page > 1) { %>
-                                                    [<a href="search.do?search=<%= search %>&page=1">First</a>/
-                                                     <a href="search.do?search=<%= search %>&page=<%= page - 1 %>">Prev</a>]
-                                                <% } else { %>
-                                                    [First/Prev]
-                                                <% } %>
+                                            <!-- First / Prev -->
+                                            <% if (pageNum > 1) { %>
+                                                [<a href="search.do?search=<%= search %>&page=1">First</a>/
+                                                 <a href="search.do?search=<%= search %>&page=<%= pageNum - 1 %>">Prev</a>]
+                                            <% } else { %>
+                                                [First/Prev]
+                                            <% } %>
 
-                                                <!-- Current page -->
-                                                <strong><%= page %></strong>
+                                            <strong><%= pageNum %></strong>
 
-                                                <!-- Next / Last -->
-                                                <% if (hasNext) { %>
-                                                    [<a href="search.do?search=<%= search %>&page=<%= page + 1 %>">Next</a>/
-                                                     <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
-                                                <% } else { %>
-                                                    [Next/Last]
-                                                <% } %>
-                                            </span>
+                                            <!-- Next / Last -->
+                                            <% if (hasNext) { %>
+                                                [<a href="search.do?search=<%= search %>&page=<%= pageNum + 1 %>">Next</a>/
+                                                 <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
+                                            <% } else { %>
+                                                [Next/Last]
+                                            <% } %>
+                                        </span>
 
                                             <!-- Results table -->
                                             <table class="table" id="result">

--- a/search.jsp
+++ b/search.jsp
@@ -211,8 +211,6 @@
                                 </div>
                             </logic:present>
 
-
-
                             <div class="submitc">
                                 <div class="function previous">
                                     <span class="tl"></span>

--- a/search.jsp
+++ b/search.jsp
@@ -138,7 +138,7 @@
                                         </div>
                                     </div>
                                 </div>
-                            </logic:present>
+                            </logic:equal>
 
                             <!-- Request-scoped results (API/non-UI users) -->
                             <logic:equal name="isUI" value="false" scope="request">

--- a/search.jsp
+++ b/search.jsp
@@ -145,11 +145,6 @@
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
-
-
-
-                                        <div class="result">
-
                                         <%
                                             String isUI = (String) request.getAttribute("isUI");
                                             if ("false".equals(isUI)) {
@@ -161,10 +156,9 @@
                                                 Long   totalResults = (Long)    request.getAttribute("totalResults");
 
                                                 if (totalResults > 0) {
-
                                         %>
-                                                <div class="result">
-                                                  <span class="pagebanner">
+                                        <div class="result">
+                                            <span class="pagebanner">
                                                     <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
                                         <%
                                                     String hasNextPage = (String) request.getAttribute("hasNextPage");

--- a/search.jsp
+++ b/search.jsp
@@ -151,102 +151,68 @@
                                 </div>
                             </logic:present>
 
-<!-- Output format for non-ui requests (DB-paged, scraper-friendly) -->
-<!-- This replaces your entire current non-UI block -->
-<logic:present name="results" scope="request">
-  <logic:present name="startIndex" scope="request">
+                            <!-- Request-scoped results (API/non-UI users) -->
+                            <logic:present name="results" scope="request">
+                                <div class="formwrap">
+                                    <span class="tl"></span>
+                                    <span class="tr"><span></span></span>
+                                    <div class="formcon">
+                                        <h2>Search results</h2>
+                                        <p>
+                                            Showing results
+                                            <bean:write name="startIndex" scope="request"/>
+                                            &ndash;
+                                            <bean:write name="endIndex" scope="request"/>
+                                            of
+                                            <bean:write name="totalResults" scope="request"/>
+                                            (page
+                                            <bean:write name="page" scope="request"/>
+                                            of
+                                            <bean:write name="totalPages" scope="request"/>)
+                                        </p>
+                                        <div class="result">
+                                            <table class="its" cellspacing="0">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Case number</th>
+                                                        <th>Title</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <logic:iterate id="result" name="results" scope="request">
+                                                        <tr>
+                                                            <td>
+                                                                <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>">
+                                                                    <bean:write name="result" property="case_no"/>
+                                                                </a>
+                                                            </td>
+                                                            <td><bean:write name="result" property="title1"/></td>
+                                                        </tr>
+                                                    </logic:iterate>
+                                                </tbody>
+                                            </table>
+                                        </div>
 
-    <%-- TEMPORARY: Catch ANY exception inside the non-UI block and print it inline --%>
-    <% try { %>
+                                        <!-- Paging controls for non-UI clients -->
+                                        <logic:equal name="hasNextPage" value="true" scope="request">
+                                            <p>
+                                                Next page:
+                                                <bean:define id="nextPage" name="page" scope="request" type="java.lang.Integer"/>
+                                                <% int nextPageNum = ((Integer)request.getAttribute("page")) + 1; %>
+                                                <a href="search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>">
+                                                    search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>
+                                                </a>
+                                            </p>
+                                        </logic:equal>
 
-      <div class="formwrap">
-          <span class="tl"></span>
-          <span class="tr"><span></span></span>
-          <div class="formcon">
-              <h2>Search results</h2>
+                                        <logic:equal name="hasNextPage" value="false" scope="request">
+                                            <p>No further pages.</p>
+                                        </logic:equal>
 
-              <div class="result">
+                                    </div>
+                                </div>
+                            </logic:present>
 
-                  <!-- Page banner (already safe) -->
-                  <span class="pagebanner">
-                      <bean:write name="totalResults" ignore="true"/> items found, displaying
-                      <bean:write name="startIndex" ignore="true"/> to
-                      <bean:write name="endIndex" ignore="true"/>.
-                  </span>
-
-                  <!-- Page links (already safe from previous fix) -->
-                  <span class="pagelinks">
-                      <%
-                          String search = request.getParameter("search");
-                          if (search == null) search = "";
-
-                          Integer pageObj      = (Integer) request.getAttribute("page");
-                          Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
-                          String  hasNextStr   = (String)  request.getAttribute("hasNextPage");
-
-                          int pageNum    = (pageObj != null) ? pageObj.intValue() : 1;
-                          int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
-                          boolean hasNext = "true".equalsIgnoreCase(hasNextStr);
-                      %>
-
-                      <!-- First / Prev -->
-                      <% if (pageNum > 1) { %>
-                          [<a href="search.do?search=<%= search %>&page=1">First</a>/
-                           <a href="search.do?search=<%= search %>&page=<%= pageNum - 1 %>">Prev</a>]
-                      <% } else { %>
-                          [First/Prev]
-                      <% } %>
-
-                      <strong><%= pageNum %></strong>
-
-                      <!-- Next / Last -->
-                      <% if (hasNext) { %>
-                          [<a href="search.do?search=<%= search %>&page=<%= pageNum + 1 %>">Next</a>/
-                           <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
-                      <% } else { %>
-                          [Next/Last]
-                      <% } %>
-                  </span>
-
-                  <!-- Results table - now fully protected -->
-                  <table class="table" id="result">
-                      <thead>
-                          <tr>
-                              <th>Case number</th>
-                              <th>Title</th>
-                          </tr>
-                      </thead>
-                      <tbody>
-                          <logic:iterate id="row" name="results">
-                              <tr>
-                                  <td>
-                                      <a href="getDetail.do?case_id=<bean:write name='row' property='case_no' ignore='true'/>">
-                                          <bean:write name="row" property="case_no" ignore="true"/>
-                                      </a>
-                                  </td>
-                                  <td>
-                                      <bean:write name="row" property="title1" ignore="true"/>
-                                  </td>
-                              </tr>
-                          </logic:iterate>
-                      </tbody>
-                  </table>
-
-              </div>
-          </div>
-      </div>
-
-    <% } catch (Exception e) { %>
-        <!-- This will now appear in the curl response if anything throws -->
-        <h2>=== EXCEPTION CAUGHT IN NON-UI BLOCK ===</h2>
-        <pre>Message: <%= e.getMessage() %></pre>
-        <pre>Type: <%= e.getClass().getName() %></pre>
-        <h3>Stack trace:</h3>
-        <pre><% e.printStackTrace(new java.io.PrintWriter(out)); %></pre>
-    <% } %>
-
-  </logic:present>
-</logic:present>
                             <div class="submitc">
                                 <div class="function previous">
                                     <span class="tl"></span>
@@ -256,13 +222,8 @@
                                     <span class="br"></span>
                                 </div>
                             </div>
-
-
-
-
                             <!-- InstanceEndEditable -->
                         </div>
-
                     </div>
                 </div>
             </div>

--- a/search.jsp
+++ b/search.jsp
@@ -137,12 +137,9 @@
                                 </div>
                             </logic:present>
 
-                        <%
-                            try {
-                        %>
-
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
+                              <logic:present name="startIndex" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
@@ -229,14 +226,8 @@
                                         </div>
                                     </div>
                                 </div>
+                              </logic:present>
                             </logic:present>
-
-                        <%
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                                throw e;
-                            }
-                        %>
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -149,10 +149,11 @@
                                         <h2>Search results</h2>
 
                                         <%
-                                        int page         = ((Integer) request.getAttribute("page"))
+                                        String hasNextPage = (String) request.getAttribute("hasNextPage");
                                         %>
 
                                         <p>
+                                        hasNextPage<%= hasNextPage %>
                                         </p>
 
                                         <div class="result">

--- a/search.jsp
+++ b/search.jsp
@@ -152,16 +152,16 @@
                                             String isUI = (String) request.getAttribute("isUI");
                                             if ("false".equals(isUI)) {
                                                 String hasNextPage1 = (String) request.getAttribute("hasNextPage");
-                                                Long   totalResults = (Long)    request.getAttribute("totalResults");
                                                 Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                                 Integer endIndex    = (Integer) request.getAttribute("endIndex");
-                                                Integer page        = (Integer) request.getAttribute("page");
+                                                Integer pageNum     = (Integer) request.getAttribute("page");
                                                 Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>
                                             <p>
-                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
-                                                of <%= totalResults %>
-                                                (page <%= page %> of <%= totalPages %>)
+                                                StartIndex <%= startIndex %>
+                                                EndIndex <%= endIndex %>
+                                                Page <%= pageNum %>
+                                                Total Pages <%= totalPages %>)
                                             </p>
                                         <%
                                             }

--- a/search.jsp
+++ b/search.jsp
@@ -150,39 +150,58 @@
 
                                         <div class="result">
 
-                                            <!-- DisplayTag-like banner -->
+                                            <!-- Page banner -->
                                             <span class="pagebanner">
                                                 <bean:write name="totalResults"/> items found, displaying
                                                 <bean:write name="startIndex"/> to <bean:write name="endIndex"/>.
                                             </span>
 
-                                            <!-- DisplayTag-like paging links -->
+                                            <!-- Page links -->
                                             <span class="pagelinks">
 
-                                                <!-- First / Prev -->
-                                                <logic:greaterThan name="page" value="1">
-                                                    [<a href="search.do?search=${param.search}&page=1">First</a>/
-                                                    <a href="search.do?search=${param.search}&page=${page - 1}">Prev</a>]
-                                                </logic:greaterThan>
-                                                <logic:lessEqual name="page" value="1">
-                                                    [First/Prev]
-                                                </logic:lessEqual>
+                                                <%
+                                                    String search = request.getParameter("search");
+                                                    if (search == null) search = "";
 
-                                                <!-- Current page -->
-                                                <strong><bean:write name="page"/></strong>
+                                                    int page = ((Integer) request.getAttribute("page")).intValue();
+                                                    int totalPages = ((Integer) request.getAttribute("totalPages")).intValue();
+                                                    String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                                %>
+
+                                                <!-- First / Prev -->
+                                                <%
+                                                    if (page > 1) {
+                                                %>
+                                                    [<a href="search.do?search=<%= search %>&page=1">First</a>/
+                                                    <a href="search.do?search=<%= search %>&page=<%= page - 1 %>">Prev</a>]
+                                                <%
+                                                    } else {
+                                                %>
+                                                    [First/Prev]
+                                                <%
+                                                    }
+                                                %>
+
+                                                <!-- Page numbers (simple version like DisplayTag) -->
+                                                <strong><%= page %></strong>
 
                                                 <!-- Next / Last -->
-                                                <logic:equal name="hasNextPage" value="true">
-                                                    [<a href="search.do?search=${param.search}&page=${page + 1}">Next</a>/
-                                                    <a href="search.do?search=${param.search}&page=${totalPages}">Last</a>]
-                                                </logic:equal>
-                                                <logic:notEqual name="hasNextPage" value="true">
+                                                <%
+                                                    if ("true".equals(hasNextPage)) {
+                                                %>
+                                                    [<a href="search.do?search=<%= search %>&page=<%= page + 1 %>">Next</a>/
+                                                    <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
+                                                <%
+                                                    } else {
+                                                %>
                                                     [Next/Last]
-                                                </logic:notEqual>
+                                                <%
+                                                    }
+                                                %>
 
                                             </span>
 
-                                            <!-- Table -->
+                                            <!-- Results table -->
                                             <table class="table" id="result">
                                                 <thead>
                                                     <tr>

--- a/search.jsp
+++ b/search.jsp
@@ -61,6 +61,11 @@
     <script language="JavaScript" type="text/javascript" src="js/general.js"></script>
 </head>
 
+
+<%
+    try {
+%>
+
 <body>
 <a name="top" id="top"></a>
 <div class="iewrapper">
@@ -269,6 +274,14 @@
 </noscript>
 <!--END_EXCLUDE-->
 </body>
+
+<%
+    } catch (Exception e) {
+        e.printStackTrace();
+        throw e;
+    }
+%>
+
 <script>
     (function (i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r;

--- a/search.jsp
+++ b/search.jsp
@@ -150,53 +150,45 @@
 
                                             <!-- Page banner -->
                                             <span class="pagebanner">
-                                                <bean:write name="totalResults"/> items found, displaying
-                                                <bean:write name="startIndex"/> to <bean:write name="endIndex"/>.
+                                                <bean:write name="totalResults" ignore="true"/> items found, displaying
+                                                <bean:write name="startIndex" ignore="true"/> to
+                                                <bean:write name="endIndex" ignore="true"/>.
                                             </span>
 
                                             <!-- Page links -->
                                             <span class="pagelinks">
-
                                                 <%
                                                     String search = request.getParameter("search");
                                                     if (search == null) search = "";
 
-                                                    int page = ((Integer) request.getAttribute("page")).intValue();
-                                                    int totalPages = ((Integer) request.getAttribute("totalPages")).intValue();
+                                                    // Safe extraction with defaults
+                                                    Integer pageObj = (Integer) request.getAttribute("page");
+                                                    Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
                                                     String hasNextPage = (String) request.getAttribute("hasNextPage");
+
+                                                    int page = (pageObj != null) ? pageObj.intValue() : 1;
+                                                    int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
+                                                    boolean hasNext = "true".equalsIgnoreCase(hasNextPage);
                                                 %>
 
                                                 <!-- First / Prev -->
-                                                <%
-                                                    if (page > 1) {
-                                                %>
+                                                <% if (page > 1) { %>
                                                     [<a href="search.do?search=<%= search %>&page=1">First</a>/
-                                                    <a href="search.do?search=<%= search %>&page=<%= page - 1 %>">Prev</a>]
-                                                <%
-                                                    } else {
-                                                %>
+                                                     <a href="search.do?search=<%= search %>&page=<%= page - 1 %>">Prev</a>]
+                                                <% } else { %>
                                                     [First/Prev]
-                                                <%
-                                                    }
-                                                %>
+                                                <% } %>
 
-                                                <!-- Page numbers (simple version like DisplayTag) -->
+                                                <!-- Current page -->
                                                 <strong><%= page %></strong>
 
                                                 <!-- Next / Last -->
-                                                <%
-                                                    if ("true".equals(hasNextPage)) {
-                                                %>
+                                                <% if (hasNext) { %>
                                                     [<a href="search.do?search=<%= search %>&page=<%= page + 1 %>">Next</a>/
-                                                    <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
-                                                <%
-                                                    } else {
-                                                %>
+                                                     <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
+                                                <% } else { %>
                                                     [Next/Last]
-                                                <%
-                                                    }
-                                                %>
-
+                                                <% } %>
                                             </span>
 
                                             <!-- Results table -->

--- a/search.jsp
+++ b/search.jsp
@@ -151,6 +151,7 @@
                                 </div>
                             </logic:present>
 
+<%--
                             <!-- Request-scoped results (API/non-UI users) -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
@@ -212,6 +213,8 @@
                                     </div>
                                 </div>
                             </logic:present>
+
+                            --%>
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -150,7 +150,11 @@
 
                                         <p>
                                         <%
+
+                                        <%--
                                             Long   totalResults = (Long)    request.getAttribute("totalResults");
+                                        --%>
+
                                             Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                             Integer page        = (Integer) request.getAttribute("page");

--- a/search.jsp
+++ b/search.jsp
@@ -149,9 +149,6 @@
                                         <h2>Search results</h2>
 
                                         <p>
-                                        <%
-                                            Integer page        = (Integer) request.getAttribute("page");
-                                        %>
                                         </p>
 
                                         <div class="result">

--- a/search.jsp
+++ b/search.jsp
@@ -145,6 +145,9 @@
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
+
+
+
                                         <div class="result">
 
                                         <%
@@ -156,22 +159,28 @@
                                                 Integer pageNum     = (Integer) request.getAttribute("page");
                                                 Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                                 Long   totalResults = (Long)    request.getAttribute("totalResults");
+
+                                                if (totalResults > 0) {
+
                                         %>
-                                        <span class="pagebanner">
-                                            <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
+                                                <div class="result">
+                                                  <span class="pagebanner">
+                                                    <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
                                         <%
-                                                String hasNextPage = (String) request.getAttribute("hasNextPage");
-                                                if ("true".equals(hasNextPage)) {
-                                                    int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
-                                                    int pageSize    = ((Integer) request.getAttribute("pageSize"));
-                                                    String srchStr  = (String)  request.getAttribute("searchString");
-                                        %>
-                                        </span>
+                                                    String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                                    if ("true".equals(hasNextPage)) {
+                                                        int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
+                                                        int pageSize    = ((Integer) request.getAttribute("pageSize"));
+                                                        String srchStr  = (String)  request.getAttribute("searchString");
+                                        %></span>
                                         <span class="pagelinks">
+                                            <strong>1</strong>,
                                             [<a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
                                             Next</a>]
-                                        <% } else { %>
-                                            <p>No further pages.</p>
+                                        <% } } else { %>
+                                            <div class="result">
+                                                Nothing found to display.
+                                            </div>
                                         <% } %>
                                         </span>
                                         <%

--- a/search.jsp
+++ b/search.jsp
@@ -120,7 +120,7 @@
                             </div>
 
                             <!-- Session-scoped results (UI paging) -->
-                            <logic:present name="results" scope="session">
+                            <logic:equal name="isUI" value="true" scope="session">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
@@ -141,7 +141,7 @@
                             </logic:present>
 
                             <!-- Request-scoped results (API/non-UI users) -->
-                            <logic:present name="results" scope="request">
+                            <logic:equal name="isUI" value="false" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
@@ -150,14 +150,10 @@
 
                                         <%
                                             String hasNextPage1 = (String) request.getAttribute("hasNextPage");
-                                            if (hasNextPage1 != null) {
                                         %>
                                             <p>
                                                 Has Next Page <%= hasNextPage1 %>
                                             </p>
-                                        <%
-                                            }
-                                        %>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">
@@ -202,7 +198,7 @@
 
                                     </div>
                                 </div>
-                            </logic:present>
+                            </logic:equal>
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -150,11 +150,9 @@
 
                                         <p>
                                         <%
-                                            Long   totalResults = (Long)    request.getAttribute("totalResults");
                                             Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                             Integer page        = (Integer) request.getAttribute("page");
-                                            Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>
                                         </p>
 

--- a/search.jsp
+++ b/search.jsp
@@ -150,6 +150,13 @@
 
                                         <%
                                             String hasNextPage1 = (String) request.getAttribute("hasNextPage");
+                                            if (hasNextPage1 != null) {
+                                        %>
+                                            <p>
+                                                Has Next Page <%= hasNextPage1 %>
+                                            </p>
+                                        <%
+                                            }
                                         %>
 
                                         <div class="result">

--- a/search.jsp
+++ b/search.jsp
@@ -164,6 +164,10 @@
                                                 Page <%= pageNum %>
                                                 Total Pages <%= totalPages %>)
                                                 Total Results <%= totalResults %>
+
+                                                    Showing results <%= startIndex %> &ndash; <%= endIndex %>
+                                                    of <%= totalResults %>
+                                                    (page <%= page %> of <%= totalPages %>)
                                             </p>
                                         <%
                                             }

--- a/search.jsp
+++ b/search.jsp
@@ -148,6 +148,10 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
 
+                                        <%
+                                        int page         = ((Integer) request.getAttribute("page"))
+                                        %>
+
                                         <p>
                                         </p>
 

--- a/search.jsp
+++ b/search.jsp
@@ -119,7 +119,6 @@
                                 </div>
                             </div>
 
-                            <!-- Session-scoped results (UI paging) -->
                             <logic:equal name="isUI" value="true" scope="session">
                                 <div class="formwrap">
                                     <span class="tl"></span>
@@ -140,13 +139,13 @@
                                 </div>
                             </logic:equal>
 
-                            <!-- Request-scoped results (API/non-UI users) -->
                             <logic:equal name="isUI" value="false" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
+                                        <div class="result">
 
                                         <%
                                             String isUI = (String) request.getAttribute("isUI");
@@ -158,16 +157,28 @@
                                                 Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                                 Long   totalResults = (Long)    request.getAttribute("totalResults");
                                         %>
-                                            <p>
-                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
-                                                of <%= totalResults %>
-                                                (page <%= page %> of <%= totalPages %>)
-                                            </p>
+                                        <span class="pagebanner">
+                                            <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>
+
+                                        <!-- Paging controls for non-UI clients -->
+                                        <%
+                                                String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                                if ("true".equals(hasNextPage)) {
+                                                    int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
+                                                    int pageSize    = ((Integer) request.getAttribute("pageSize"));
+                                                    String srchStr  = (String)  request.getAttribute("searchString");
+                                        %>
+                                                Next:
+                                                <a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
+                                                    search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>
+                                                </a>
+                                        <% } else { %>
+                                            <p>No further pages.</p>
+                                        <% } %>
+                                        </span>
                                         <%
                                             }
                                         %>
-
-                                        <div class="result">
                                             <table class="its" cellspacing="0">
                                                 <thead>
                                                     <tr>
@@ -190,23 +201,6 @@
                                             </table>
                                         </div>
 
-                                        <!-- Paging controls for non-UI clients -->
-                                        <%
-                                            String hasNextPage = (String) request.getAttribute("hasNextPage");
-                                            if ("true".equals(hasNextPage)) {
-                                                int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
-                                                int pageSize    = ((Integer) request.getAttribute("pageSize"));
-                                                String srchStr  = (String)  request.getAttribute("searchString");
-                                        %>
-                                            <p>
-                                                Next page:
-                                                <a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
-                                                    search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>
-                                                </a>
-                                            </p>
-                                        <% } else { %>
-                                            <p>No further pages.</p>
-                                        <% } %>
 
                                     </div>
                                 </div>
@@ -252,7 +246,7 @@
 <!--BEGIN_EXCLUDE-->
 <noscript>
     <div>
-        <img src='http://directgov.stcllctrs.com/OWCPZPDTRUV/noScript.bmp' alt="Scipt is not enabled"/>
+        <img src='http://directgov.stcllctrs.com/OWCPZPDTRUV/noScript.bmp' alt="Script is not enabled"/>
     </div>
 </noscript>
 <!--END_EXCLUDE-->

--- a/search.jsp
+++ b/search.jsp
@@ -158,7 +158,7 @@
                                                 Long   totalResults = (Long)    request.getAttribute("totalResults");
                                         %>
                                         <span class="pagebanner">
-                                            <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>
+                                            <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
                                         <%
                                                 String hasNextPage = (String) request.getAttribute("hasNextPage");
                                                 if ("true".equals(hasNextPage)) {
@@ -189,9 +189,7 @@
                                                         <tr>
                                                             <td>
                                                             <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>"><bean:write name="result" property="case_no"/></a></td>
-                                                            <td><bean:write name="result" property="title1"/></td>
-                                                        </tr>
-                                                    </logic:iterate>
+                                                            <td><bean:write name="result" property="title1"/></td></tr></logic:iterate>
                                                 </tbody>
                                             </table>
                                         </div>

--- a/search.jsp
+++ b/search.jsp
@@ -149,11 +149,17 @@
                                         <h2>Search results</h2>
 
                                         <%
-                                            String hasNextPage1 = (String) request.getAttribute("hasNextPage");
+
+                                            String isUI = (String) request.getAttribute("isUI");
+                                            if ("false".equals(isUI)) {
+                                                String hasNextPage1 = (String) request.getAttribute("hasNextPage");
                                         %>
                                             <p>
                                                 Has Next Page <%= hasNextPage1 %>
                                             </p>
+                                        <%
+                                            }
+                                        %>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -159,8 +159,6 @@
                                         %>
                                         <span class="pagebanner">
                                             <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>
-
-                                        <!-- Paging controls for non-UI clients -->
                                         <%
                                                 String hasNextPage = (String) request.getAttribute("hasNextPage");
                                                 if ("true".equals(hasNextPage)) {
@@ -168,10 +166,10 @@
                                                     int pageSize    = ((Integer) request.getAttribute("pageSize"));
                                                     String srchStr  = (String)  request.getAttribute("searchString");
                                         %>
-                                                Next:
-                                                <a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
-                                                    search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>
-                                                </a>
+                                        </span>
+                                        <span class="pagelinks">
+                                            [<a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
+                                            Next</a>]
                                         <% } else { %>
                                             <p>No further pages.</p>
                                         <% } %>

--- a/search.jsp
+++ b/search.jsp
@@ -151,88 +151,102 @@
                                 </div>
                             </logic:present>
 
-                            <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
-                            <logic:present name="results" scope="request">
-                              <logic:present name="startIndex" scope="request">
-                                <div class="formwrap">
-                                    <span class="tl"></span>
-                                    <span class="tr"><span></span></span>
-                                    <div class="formcon">
-                                        <h2>Search results</h2>
+<!-- Output format for non-ui requests (DB-paged, scraper-friendly) -->
+<!-- This replaces your entire current non-UI block -->
+<logic:present name="results" scope="request">
+  <logic:present name="startIndex" scope="request">
 
-                                        <div class="result">
+    <%-- TEMPORARY: Catch ANY exception inside the non-UI block and print it inline --%>
+    <% try { %>
 
-                                        <!-- Page banner -->
-                                        <span class="pagebanner">
-                                            <bean:write name="totalResults" ignore="true"/> items found, displaying
-                                            <bean:write name="startIndex" ignore="true"/> to
-                                            <bean:write name="endIndex" ignore="true"/>.
-                                        </span>
+      <div class="formwrap">
+          <span class="tl"></span>
+          <span class="tr"><span></span></span>
+          <div class="formcon">
+              <h2>Search results</h2>
 
-                                        <!-- Page links -->
-                                        <span class="pagelinks">
-                                            <%
-                                                String search = request.getParameter("search");
-                                                if (search == null) search = "";
+              <div class="result">
 
-                                                Integer pageObj      = (Integer) request.getAttribute("page");
-                                                Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
-                                                String  hasNextStr   = (String)  request.getAttribute("hasNextPage");
+                  <!-- Page banner (already safe) -->
+                  <span class="pagebanner">
+                      <bean:write name="totalResults" ignore="true"/> items found, displaying
+                      <bean:write name="startIndex" ignore="true"/> to
+                      <bean:write name="endIndex" ignore="true"/>.
+                  </span>
 
-                                                int pageNum    = (pageObj != null) ? pageObj.intValue() : 1;
-                                                int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
-                                                boolean hasNext = "true".equalsIgnoreCase(hasNextStr);
-                                            %>
+                  <!-- Page links (already safe from previous fix) -->
+                  <span class="pagelinks">
+                      <%
+                          String search = request.getParameter("search");
+                          if (search == null) search = "";
 
-                                            <!-- First / Prev -->
-                                            <% if (pageNum > 1) { %>
-                                                [<a href="search.do?search=<%= search %>&page=1">First</a>/
-                                                 <a href="search.do?search=<%= search %>&page=<%= pageNum - 1 %>">Prev</a>]
-                                            <% } else { %>
-                                                [First/Prev]
-                                            <% } %>
+                          Integer pageObj      = (Integer) request.getAttribute("page");
+                          Integer totalPagesObj = (Integer) request.getAttribute("totalPages");
+                          String  hasNextStr   = (String)  request.getAttribute("hasNextPage");
 
-                                            <strong><%= pageNum %></strong>
+                          int pageNum    = (pageObj != null) ? pageObj.intValue() : 1;
+                          int totalPages = (totalPagesObj != null) ? totalPagesObj.intValue() : 1;
+                          boolean hasNext = "true".equalsIgnoreCase(hasNextStr);
+                      %>
 
-                                            <!-- Next / Last -->
-                                            <% if (hasNext) { %>
-                                                [<a href="search.do?search=<%= search %>&page=<%= pageNum + 1 %>">Next</a>/
-                                                 <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
-                                            <% } else { %>
-                                                [Next/Last]
-                                            <% } %>
-                                        </span>
+                      <!-- First / Prev -->
+                      <% if (pageNum > 1) { %>
+                          [<a href="search.do?search=<%= search %>&page=1">First</a>/
+                           <a href="search.do?search=<%= search %>&page=<%= pageNum - 1 %>">Prev</a>]
+                      <% } else { %>
+                          [First/Prev]
+                      <% } %>
 
-                                            <!-- Results table -->
-                                            <table class="table" id="result">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Case number</th>
-                                                        <th>Title</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <logic:iterate id="row" name="results">
-                                                        <tr>
-                                                            <td>
-                                                                <a href="getDetail.do?case_id=<bean:write name='row' property='case_no'/>">
-                                                                    <bean:write name="row" property="case_no"/>
-                                                                </a>
-                                                            </td>
-                                                            <td>
-                                                                <bean:write name="row" property="title1"/>
-                                                            </td>
-                                                        </tr>
-                                                    </logic:iterate>
-                                                </tbody>
-                                            </table>
+                      <strong><%= pageNum %></strong>
 
-                                        </div>
-                                    </div>
-                                </div>
-                              </logic:present>
-                            </logic:present>
+                      <!-- Next / Last -->
+                      <% if (hasNext) { %>
+                          [<a href="search.do?search=<%= search %>&page=<%= pageNum + 1 %>">Next</a>/
+                           <a href="search.do?search=<%= search %>&page=<%= totalPages %>">Last</a>]
+                      <% } else { %>
+                          [Next/Last]
+                      <% } %>
+                  </span>
 
+                  <!-- Results table - now fully protected -->
+                  <table class="table" id="result">
+                      <thead>
+                          <tr>
+                              <th>Case number</th>
+                              <th>Title</th>
+                          </tr>
+                      </thead>
+                      <tbody>
+                          <logic:iterate id="row" name="results">
+                              <tr>
+                                  <td>
+                                      <a href="getDetail.do?case_id=<bean:write name='row' property='case_no' ignore='true'/>">
+                                          <bean:write name="row" property="case_no" ignore="true"/>
+                                      </a>
+                                  </td>
+                                  <td>
+                                      <bean:write name="row" property="title1" ignore="true"/>
+                                  </td>
+                              </tr>
+                          </logic:iterate>
+                      </tbody>
+                  </table>
+
+              </div>
+          </div>
+      </div>
+
+    <% } catch (Exception e) { %>
+        <!-- This will now appear in the curl response if anything throws -->
+        <h2>=== EXCEPTION CAUGHT IN NON-UI BLOCK ===</h2>
+        <pre>Message: <%= e.getMessage() %></pre>
+        <pre>Type: <%= e.getClass().getName() %></pre>
+        <h3>Stack trace:</h3>
+        <pre><% e.printStackTrace(new java.io.PrintWriter(out)); %></pre>
+    <% } %>
+
+  </logic:present>
+</logic:present>
                             <div class="submitc">
                                 <div class="function previous">
                                     <span class="tl"></span>

--- a/search.jsp
+++ b/search.jsp
@@ -62,9 +62,6 @@
 </head>
 
 
-<%
-    try {
-%>
 
 <body>
 <a name="top" id="top"></a>
@@ -89,6 +86,11 @@
                     <div id="Content">
                         <div class="holder">
                             <!-- InstanceBeginEditable name="main" -->
+
+
+                        <%
+                            try {
+                        %>
 
                             <div class="steps">
                                 <h2>Ways to Search</h2>
@@ -237,6 +239,15 @@
                                     <span class="br"></span>
                                 </div>
                             </div>
+
+                        <%
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                                throw e;
+                            }
+                        %>
+
+
                             <!-- InstanceEndEditable -->
                         </div>
 
@@ -275,12 +286,6 @@
 <!--END_EXCLUDE-->
 </body>
 
-<%
-    } catch (Exception e) {
-        e.printStackTrace();
-        throw e;
-    }
-%>
 
 <script>
     (function (i, s, o, g, r, a, m) {

--- a/search.jsp
+++ b/search.jsp
@@ -149,12 +149,8 @@
                                         <h2>Search results</h2>
 
                                         <%
-                                        String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                            String hasNextPage1 = (String) request.getAttribute("hasNextPage");
                                         %>
-
-                                        <p>
-                                        hasNextPage<%= hasNextPage %>
-                                        </p>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -149,14 +149,19 @@
                                         <h2>Search results</h2>
 
                                         <%
-
                                             String isUI = (String) request.getAttribute("isUI");
-                                            String hasNextPage1 = (String) request.getAttribute("hasNextPage");
-
                                             if ("false".equals(isUI)) {
+                                                String hasNextPage1 = (String) request.getAttribute("hasNextPage");
+                                                Long   totalResults = (Long)    request.getAttribute("totalResults");
+                                                Integer startIndex  = (Integer) request.getAttribute("startIndex");
+                                                Integer endIndex    = (Integer) request.getAttribute("endIndex");
+                                                Integer page        = (Integer) request.getAttribute("page");
+                                                Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>
                                             <p>
-                                                Has Next Page <%= hasNextPage1 %>
+                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
+                                                of <%= totalResults %>
+                                                (page <%= page %> of <%= totalPages %>)
                                             </p>
                                         <%
                                             }

--- a/search.jsp
+++ b/search.jsp
@@ -171,11 +171,12 @@
                                             <strong>1</strong>,
                                             [<a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
                                             Next</a>]
-                                        <% } } else { %>
+                                        <% } else { %>
+                                        <span class="pagelinks">No more results</span>
+                                        <% } else {%>
                                             <div class="result">
                                                 Nothing found to display.
                                             </div>
-                                        <% } %>
                                         </span>
                                         <%
                                             }
@@ -196,8 +197,6 @@
                                                 </tbody>
                                             </table>
                                         </div>
-
-
                                     </div>
                                 </div>
                             </logic:equal>

--- a/search.jsp
+++ b/search.jsp
@@ -150,8 +150,6 @@
 
                                         <p>
                                         <%
-                                            Integer startIndex  = (Integer) request.getAttribute("startIndex");
-                                            Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                             Integer page        = (Integer) request.getAttribute("page");
                                         %>
                                         </p>

--- a/search.jsp
+++ b/search.jsp
@@ -148,20 +148,18 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
 
-                                        <%--
                                         <p>
-                                            Showing results
-                                            <bean:write name="startIndex" scope="request"/>
-                                            &ndash;
-                                            <bean:write name="endIndex" scope="request"/>
-                                            of
-                                            <bean:write name="totalResults" scope="request"/>
-                                            (page
-                                            <bean:write name="page" scope="request"/>
-                                            of
-                                            <bean:write name="totalPages" scope="request"/>)
+                                        <%
+                                            Long   totalResults = (Long)    request.getAttribute("totalResults");
+                                            Integer startIndex  = (Integer) request.getAttribute("startIndex");
+                                            Integer endIndex    = (Integer) request.getAttribute("endIndex");
+                                            Integer page        = (Integer) request.getAttribute("page");
+                                            Integer totalPages  = (Integer) request.getAttribute("totalPages");
+                                        %>
+                                            Showing results <%= startIndex %> &ndash; <%= endIndex %>
+                                            of <%= totalResults %>
+                                            (page <%= page %> of <%= totalPages %>)
                                         </p>
-                                        --%>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -110,6 +110,8 @@
                                 </div>
                             </div>
 
+
+<%--
                             <!-- Session-scoped results (UI paging) -->
                             <logic:present name="results" scope="session">
                                 <div class="formwrap">
@@ -130,6 +132,7 @@
                                     </div>
                                 </div>
                             </logic:present>
+
 
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
@@ -220,6 +223,9 @@
                                     </div>
                                 </div>
                             </logic:present>
+--%>
+
+
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -163,6 +163,7 @@
                                                 EndIndex <%= endIndex %>
                                                 Page <%= pageNum %>
                                                 Total Pages <%= totalPages %>)
+                                                Total Results <%= totalResults %>
                                             </p>
                                         <%
                                             }

--- a/search.jsp
+++ b/search.jsp
@@ -147,6 +147,8 @@
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
+
+                                        <%--
                                         <p>
                                             Showing results
                                             <bean:write name="startIndex" scope="request"/>
@@ -159,6 +161,8 @@
                                             of
                                             <bean:write name="totalPages" scope="request"/>)
                                         </p>
+                                        --%>
+
                                         <div class="result">
                                             <table class="its" cellspacing="0">
                                                 <thead>

--- a/search.jsp
+++ b/search.jsp
@@ -88,9 +88,6 @@
                             <!-- InstanceBeginEditable name="main" -->
 
 
-                        <%
-                            try {
-                        %>
 
                             <div class="steps">
                                 <h2>Ways to Search</h2>
@@ -139,6 +136,10 @@
                                     </div>
                                 </div>
                             </logic:present>
+
+                        <%
+                            try {
+                        %>
 
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
@@ -230,6 +231,13 @@
                                 </div>
                             </logic:present>
 
+                        <%
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                                throw e;
+                            }
+                        %>
+
                             <div class="submitc">
                                 <div class="function previous">
                                     <span class="tl"></span>
@@ -240,12 +248,7 @@
                                 </div>
                             </div>
 
-                        <%
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                                throw e;
-                            }
-                        %>
+
 
 
                             <!-- InstanceEndEditable -->

--- a/search.jsp
+++ b/search.jsp
@@ -153,10 +153,11 @@
 
                                         <%--
                                             Long   totalResults = (Long)    request.getAttribute("totalResults");
-                                        --%>
-
                                             Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
+                                        --%>
+
+
                                             Integer page        = (Integer) request.getAttribute("page");
                                             Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>

--- a/search.jsp
+++ b/search.jsp
@@ -159,15 +159,9 @@
                                                 Long   totalResults = (Long)    request.getAttribute("totalResults");
                                         %>
                                             <p>
-                                                StartIndex <%= startIndex %>
-                                                EndIndex <%= endIndex %>
-                                                Page <%= pageNum %>
-                                                Total Pages <%= totalPages %>)
-                                                Total Results <%= totalResults %>
-
-                                                    Showing results <%= startIndex %> &ndash; <%= endIndex %>
-                                                    of <%= totalResults %>
-                                                    (page <%= page %> of <%= totalPages %>)
+                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
+                                                of <%= totalResults %>
+                                                (page <%= page %> of <%= totalPages %>)
                                             </p>
                                         <%
                                             }

--- a/search.jsp
+++ b/search.jsp
@@ -143,44 +143,49 @@
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
-                                    <div class="formcon">
-                                        <h2>Search results</h2>
-                                        <%
-                                            String isUI = (String) request.getAttribute("isUI");
-                                            if ("false".equals(isUI)) {
-                                                String hasNextPage1 = (String)  request.getAttribute("hasNextPage");
-                                                Integer startIndex  = (Integer) request.getAttribute("startIndex");
-                                                Integer endIndex    = (Integer) request.getAttribute("endIndex");
-                                                Integer pageNum     = (Integer) request.getAttribute("page");
-                                                Integer totalPages  = (Integer) request.getAttribute("totalPages");
-                                                Long   totalResults = (Long)    request.getAttribute("totalResults");
+                                <div class="formcon">
+                                    <h2>Search results</h2>
+                                    <%
+                                        String isUI = (String) request.getAttribute("isUI");
+                                        if ("false".equals(isUI)) {
+                                            String hasNextPage1 = (String)  request.getAttribute("hasNextPage");
+                                            Integer startIndex   = (Integer) request.getAttribute("startIndex");
+                                            Integer endIndex     = (Integer) request.getAttribute("endIndex");
+                                            Integer pageNum      = (Integer) request.getAttribute("page");
+                                            Integer totalPages   = (Integer) request.getAttribute("totalPages");
+                                            Long   totalResults = (Long)    request.getAttribute("totalResults");
 
-                                                if (totalResults > 0) {
-                                        %>
+                                            if (totalResults > 0) {
+                                    %>
                                         <div class="result">
                                             <span class="pagebanner">
-                                                    <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
-                                        <%
-                                                    String hasNextPage = (String) request.getAttribute("hasNextPage");
-                                                    if ("true".equals(hasNextPage)) {
-                                                        int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
-                                                        int pageSize    = ((Integer) request.getAttribute("pageSize"));
-                                                        String srchStr  = (String)  request.getAttribute("searchString");
-                                        %></span>
-                                        <span class="pagelinks">
-                                            <strong>1</strong>,
-                                            [<a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
-                                            Next</a>]
-                                        <% } else { %>
-                                        <span class="pagelinks">No more results</span>
-                                        <% } else {%>
-                                            <div class="result">
-                                                Nothing found to display.
-                                            </div>
-                                        </span>
-                                        <%
+                                                <%= totalResults %> items found, displaying <%= startIndex %> to <%= endIndex %>.
+                                            </span>
+                                            <%
+                                                String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                                if ("true".equals(hasNextPage)) {
+                                                    int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
+                                                    int pageSize    = ((Integer) request.getAttribute("pageSize"));
+                                                    String srchStr  = (String)  request.getAttribute("searchString");
+                                            %>
+                                            <span class="pagelinks">
+                                                <strong>1</strong>,
+                                                [<a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">Next</a>]
+                                            </span>
+                                            <% } else { %>
+                                            <span class="pagelinks">No more results</span>
+                                            <% } %>
+                                        </div>
+                                    <%
+                                            } else {
+                                    %>
+                                        <div class="result">
+                                            Nothing found to display.
+                                        </div>
+                                    <%
                                             }
-                                        %>
+                                        }
+                                    %>
                                             <table class="table" id="result">
                                                 <thead>
                                                     <tr>

--- a/search.jsp
+++ b/search.jsp
@@ -151,11 +151,12 @@
                                         <%
                                             String isUI = (String) request.getAttribute("isUI");
                                             if ("false".equals(isUI)) {
-                                                String hasNextPage1 = (String) request.getAttribute("hasNextPage");
+                                                String hasNextPage1 = (String)  request.getAttribute("hasNextPage");
                                                 Integer startIndex  = (Integer) request.getAttribute("startIndex");
                                                 Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                                 Integer pageNum     = (Integer) request.getAttribute("page");
                                                 Integer totalPages  = (Integer) request.getAttribute("totalPages");
+                                                Long   totalResults = (Long)    request.getAttribute("totalResults");
                                         %>
                                             <p>
                                                 StartIndex <%= startIndex %>

--- a/search.jsp
+++ b/search.jsp
@@ -155,11 +155,14 @@
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                             Integer page        = (Integer) request.getAttribute("page");
                                             Integer totalPages  = (Integer) request.getAttribute("totalPages");
+
+                                            if (totalResults != null) {
                                         %>
-                                            Showing results <%= startIndex %> &ndash; <%= endIndex %>
-                                            of <%= totalResults %>
-                                            (page <%= page %> of <%= totalPages %>)
+                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
+                                                of <%= totalResults %>
+                                                (page <%= page %> of <%= totalPages %>)
                                         </p>
+                                        <% } %>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -133,7 +133,6 @@
                                 </div>
                             </logic:present>
 
-<%--
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
@@ -223,8 +222,6 @@
                                     </div>
                                 </div>
                             </logic:present>
---%>
-
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -155,14 +155,14 @@
                                             Integer endIndex    = (Integer) request.getAttribute("endIndex");
                                             Integer page        = (Integer) request.getAttribute("page");
                                             Integer totalPages  = (Integer) request.getAttribute("totalPages");
-
-                                            if (totalResults != null) {
                                         %>
+
+                                        <%--
                                                 Showing results <%= startIndex %> &ndash; <%= endIndex %>
                                                 of <%= totalResults %>
                                                 (page <%= page %> of <%= totalPages %>)
+                                        --%>
                                         </p>
-                                        <% } %>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -111,7 +111,7 @@
                             </div>
 
 
-<%--
+
                             <!-- Session-scoped results (UI paging) -->
                             <logic:present name="results" scope="session">
                                 <div class="formwrap">
@@ -133,7 +133,7 @@
                                 </div>
                             </logic:present>
 
-
+<%--
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
@@ -224,7 +224,6 @@
                                 </div>
                             </logic:present>
 --%>
-
 
 
                             <div class="submitc">

--- a/search.jsp
+++ b/search.jsp
@@ -119,7 +119,28 @@
                                 </div>
                             </div>
 
-                            // Output format for non-ui requests requires paging parameters (not a DisplayTag table
+                            <!-- Session-scoped results (UI paging) -->
+                            <logic:present name="results" scope="session">
+                                <div class="formwrap">
+                                    <span class="tl"></span>
+                                    <span class="tr"><span></span></span>
+                                    <div class="formcon">
+                                        <h2>Search results</h2>
+                                        <div class="result">
+                                            <display:table id="result" name="sessionScope.results" requestURI="/search.do"
+                                                           pagesize="15" sort="list">
+                                                <display:setProperty
+                                                        name="paging.banner.placement">top</display:setProperty>
+                                                <display:column property="case_no" title="Case number" paramId="case_id"
+                                                                paramProperty="case_no" href="getDetail.do"/>
+                                                <display:column property="title1" title="Title"/>
+                                            </display:table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </logic:present>
+
+                            <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>

--- a/search.jsp
+++ b/search.jsp
@@ -177,7 +177,7 @@
                                         <%
                                             }
                                         %>
-                                            <table class="its" cellspacing="0">
+                                            <table class="table" id="result">
                                                 <thead>
                                                     <tr>
                                                         <th>Case number</th>
@@ -188,10 +188,7 @@
                                                     <logic:iterate id="result" name="results" scope="request">
                                                         <tr>
                                                             <td>
-                                                                <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>">
-                                                                    <bean:write name="result" property="case_no"/>
-                                                                </a>
-                                                            </td>
+                                                            <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>"><bean:write name="result" property="case_no"/></a></td>
                                                             <td><bean:write name="result" property="title1"/></td>
                                                         </tr>
                                                     </logic:iterate>

--- a/search.jsp
+++ b/search.jsp
@@ -191,27 +191,6 @@
                                 </div>
                             </logic:present>
 
-                            <!-- Request-scoped results (API/bot users) -->
-                            <logic:present name="results" scope="request">
-                                <div class="formwrap">
-                                    <span class="tl"></span>
-                                    <span class="tr"><span></span></span>
-                                    <div class="formcon">
-                                        <h2>Search results</h2>
-                                        <div class="result">
-                                            <display:table id="result" name="requestScope.results" requestURI="/search.do"
-                                                           pagesize="5" sort="list">
-                                                <display:setProperty
-                                                        name="paging.banner.placement">top</display:setProperty>
-                                                <display:column property="case_no" title="Case number" paramId="case_id"
-                                                                paramProperty="case_no" href="getDetail.do"/>
-                                                <display:column property="title1" title="Title"/>
-                                            </display:table>
-                                        </div>
-                                    </div>
-                                </div>
-                            </logic:present>
-
                             <div class="submitc">
                                 <div class="function previous">
                                     <span class="tl"></span>

--- a/search.jsp
+++ b/search.jsp
@@ -5,6 +5,21 @@
 <%@ taglib uri="/WEB-INF/displaytag.tld" prefix="display" %>
 <%@ page import="java.sql.Date" %>
 
+<%-- FORCE exception output at the VERY beginning --%>
+<%
+    if (exception != null) {
+        out.clear();  // important: clear any partial output
+        response.setContentType("text/plain");
+        out.println("=== EXCEPTION OCCURRED IN SEARCH.JSP ===");
+        out.println("Message: " + exception.getMessage());
+        out.println("Exception type: " + exception.getClass().getName());
+        out.println("\nStack trace:");
+        exception.printStackTrace(new PrintWriter(out));
+        out.flush();
+        return;   // STOP processing the rest of the JSP
+    }
+%>
+
 <?xml version="1.0" encoding="utf-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><!-- InstanceBegin template="/Templates/default.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
@@ -115,8 +130,6 @@
                                 </div>
                             </div>
 
-
-
                             <!-- Session-scoped results (UI paging) -->
                             <logic:present name="results" scope="session">
                                 <div class="formwrap">
@@ -141,16 +154,6 @@
                             <!-- Output format for non-ui requests. Needs paging parameters; not DisplayTag table -->
                             <logic:present name="results" scope="request">
                               <logic:present name="startIndex" scope="request">
-
-
-                              <% if (exception != null) { %>
-                                  <h2>Exception occurred:</h2>
-                                  <pre><%= exception.getMessage() %></pre>
-                                  <h3>Stack trace:</h3>
-                                  <pre><% exception.printStackTrace(new java.io.PrintWriter(out)); %></pre>
-                              <% } %>
-
-
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>

--- a/search.jsp
+++ b/search.jsp
@@ -84,15 +84,6 @@
                     <div id="Content">
                         <div class="holder">
                             <!-- InstanceBeginEditable name="main" -->
-                            <% 
-                            
-                            // Check if the request has been triggered by the "Next page" link 
-                            boolean isNextPageLink="nextPage".equals(request.getParameter("action"));
-
-                            // Clear the search results if it's the "Next page" link 
-                            if (isNextPageLink) { request.getSession().removeAttribute("results"); } 
-                            
-                            %>
 
                             <div class="steps">
                                 <h2>Ways to Search</h2>

--- a/search.jsp
+++ b/search.jsp
@@ -148,7 +148,6 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
 
-                                        <%--
                                         <p>
                                         <%
                                             Long   totalResults = (Long)    request.getAttribute("totalResults");
@@ -157,11 +156,7 @@
                                             Integer page        = (Integer) request.getAttribute("page");
                                             Integer totalPages  = (Integer) request.getAttribute("totalPages");
                                         %>
-                                                Showing results <%= startIndex %> &ndash; <%= endIndex %>
-                                                of <%= totalResults %>
-                                                (page <%= page %> of <%= totalPages %>)
                                         </p>
-                                        --%>
 
                                         <div class="result">
                                             <table class="its" cellspacing="0">

--- a/search.jsp
+++ b/search.jsp
@@ -183,20 +183,22 @@
                                         </div>
 
                                         <!-- Paging controls for non-UI clients -->
-                                        <logic:equal name="hasNextPage" value="true" scope="request">
+                                        <%
+                                            String hasNextPage = (String) request.getAttribute("hasNextPage");
+                                            if ("true".equals(hasNextPage)) {
+                                                int nextPageNum = ((Integer) request.getAttribute("page")) + 1;
+                                                int pageSize    = ((Integer) request.getAttribute("pageSize"));
+                                                String srchStr  = (String)  request.getAttribute("searchString");
+                                        %>
                                             <p>
                                                 Next page:
-                                                <bean:define id="nextPage" name="page" scope="request" type="java.lang.Integer"/>
-                                                <% int nextPageNum = ((Integer)request.getAttribute("page")) + 1; %>
-                                                <a href="search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>">
-                                                    search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>
+                                                <a href="search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>">
+                                                    search.do?search=<%= srchStr %>&amp;page=<%= nextPageNum %>&amp;pageSize=<%= pageSize %>
                                                 </a>
                                             </p>
-                                        </logic:equal>
-
-                                        <logic:equal name="hasNextPage" value="false" scope="request">
+                                        <% } else { %>
                                             <p>No further pages.</p>
-                                        </logic:equal>
+                                        <% } %>
 
                                     </div>
                                 </div>

--- a/search.jsp
+++ b/search.jsp
@@ -151,8 +151,9 @@
                                         <%
 
                                             String isUI = (String) request.getAttribute("isUI");
+                                            String hasNextPage1 = (String) request.getAttribute("hasNextPage");
+
                                             if ("false".equals(isUI)) {
-                                                String hasNextPage1 = (String) request.getAttribute("hasNextPage");
                                         %>
                                             <p>
                                                 Has Next Page <%= hasNextPage1 %>

--- a/search.jsp
+++ b/search.jsp
@@ -148,26 +148,42 @@
                                     <div class="formcon">
                                         <h2>Search results</h2>
 
-                                        <!-- Paging banner (DisplayTag-like) -->
-                                        <div class="paging">
-                                            <logic:greaterThan name="page" value="1">
-                                                <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
-                                                    Previous
-                                                </a>
-                                            </logic:greaterThan>
-
-                                            Page ${page}
-
-                                            <logic:equal name="hasNextPage" value="true">
-                                                <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
-                                                    Next
-                                                </a>
-                                            </logic:equal>
-                                        </div>
-
                                         <div class="result">
-                                            <!-- Table structure mimics DisplayTag output -->
-                                            <table id="result" class="displaytag">
+
+                                            <!-- DisplayTag-like banner -->
+                                            <span class="pagebanner">
+                                                <bean:write name="totalResults"/> items found, displaying
+                                                <bean:write name="startIndex"/> to <bean:write name="endIndex"/>.
+                                            </span>
+
+                                            <!-- DisplayTag-like paging links -->
+                                            <span class="pagelinks">
+
+                                                <!-- First / Prev -->
+                                                <logic:greaterThan name="page" value="1">
+                                                    [<a href="search.do?search=${param.search}&page=1">First</a>/
+                                                    <a href="search.do?search=${param.search}&page=${page - 1}">Prev</a>]
+                                                </logic:greaterThan>
+                                                <logic:lessEqual name="page" value="1">
+                                                    [First/Prev]
+                                                </logic:lessEqual>
+
+                                                <!-- Current page -->
+                                                <strong><bean:write name="page"/></strong>
+
+                                                <!-- Next / Last -->
+                                                <logic:equal name="hasNextPage" value="true">
+                                                    [<a href="search.do?search=${param.search}&page=${page + 1}">Next</a>/
+                                                    <a href="search.do?search=${param.search}&page=${totalPages}">Last</a>]
+                                                </logic:equal>
+                                                <logic:notEqual name="hasNextPage" value="true">
+                                                    [Next/Last]
+                                                </logic:notEqual>
+
+                                            </span>
+
+                                            <!-- Table -->
+                                            <table class="table" id="result">
                                                 <thead>
                                                     <tr>
                                                         <th>Case number</th>
@@ -189,28 +205,13 @@
                                                     </logic:iterate>
                                                 </tbody>
                                             </table>
+
                                         </div>
-
-                                        <!-- Bottom paging (optional but matches DisplayTag feel) -->
-                                        <div class="paging">
-                                            <logic:greaterThan name="page" value="1">
-                                                <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
-                                                    Previous
-                                                </a>
-                                            </logic:greaterThan>
-
-                                            Page ${page}
-
-                                            <logic:equal name="hasNextPage" value="true">
-                                                <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
-                                                    Next
-                                                </a>
-                                            </logic:equal>
-                                        </div>
-
                                     </div>
                                 </div>
                             </logic:present>
+
+
 
                             <div class="submitc">
                                 <div class="function previous">

--- a/search.jsp
+++ b/search.jsp
@@ -140,23 +140,64 @@
                                 </div>
                             </logic:present>
 
-                            <!-- Request-scoped results (API/bot users) -->
+                            <!-- Request-scoped results (API/non-UI users) -->
                             <logic:present name="results" scope="request">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
+                                        <p>
+                                            Showing results
+                                            <bean:write name="startIndex" scope="request"/>
+                                            &ndash;
+                                            <bean:write name="endIndex" scope="request"/>
+                                            of
+                                            <bean:write name="totalResults" scope="request"/>
+                                            (page
+                                            <bean:write name="page" scope="request"/>
+                                            of
+                                            <bean:write name="totalPages" scope="request"/>)
+                                        </p>
                                         <div class="result">
-                                            <display:table id="result" name="requestScope.results" requestURI="/search.do"
-                                                           pagesize="50" sort="list">
-                                                <display:setProperty
-                                                        name="paging.banner.placement">top</display:setProperty>
-                                                <display:column property="case_no" title="Case number" paramId="case_id"
-                                                                paramProperty="case_no" href="getDetail.do"/>
-                                                <display:column property="title1" title="Title"/>
-                                            </display:table>
+                                            <table class="its" cellspacing="0">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Case number</th>
+                                                        <th>Title</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <logic:iterate id="result" name="results" scope="request">
+                                                        <tr>
+                                                            <td>
+                                                                <a href="getDetail.do?case_id=<bean:write name="result" property="case_no"/>">
+                                                                    <bean:write name="result" property="case_no"/>
+                                                                </a>
+                                                            </td>
+                                                            <td><bean:write name="result" property="title1"/></td>
+                                                        </tr>
+                                                    </logic:iterate>
+                                                </tbody>
+                                            </table>
                                         </div>
+
+                                        <!-- Paging controls for non-UI clients -->
+                                        <logic:equal name="hasNextPage" value="true" scope="request">
+                                            <p>
+                                                Next page:
+                                                <bean:define id="nextPage" name="page" scope="request" type="java.lang.Integer"/>
+                                                <% int nextPageNum = ((Integer)request.getAttribute("page")) + 1; %>
+                                                <a href="search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>">
+                                                    search.do?search=<bean:write name="searchString" scope="request"/>&amp;page=<%= nextPageNum %>&amp;pageSize=<bean:write name="pageSize" scope="request"/>
+                                                </a>
+                                            </p>
+                                        </logic:equal>
+
+                                        <logic:equal name="hasNextPage" value="false" scope="request">
+                                            <p>No further pages.</p>
+                                        </logic:equal>
+
                                     </div>
                                 </div>
                             </logic:present>

--- a/search_api.jsp
+++ b/search_api.jsp
@@ -84,14 +84,14 @@
                     <div id="Content">
                         <div class="holder">
                             <!-- InstanceBeginEditable name="main" -->
-                            <% 
-                            
-                            // Check if the request has been triggered by the "Next page" link 
+                            <%
+
+                            // Check if the request has been triggered by the "Next page" link
                             boolean isNextPageLink="nextPage".equals(request.getParameter("action"));
 
-                            // Clear the search results if it's the "Next page" link 
-                            if (isNextPageLink) { request.getSession().removeAttribute("results"); } 
-                            
+                            // Clear the search results if it's the "Next page" link
+                            if (isNextPageLink) { request.getSession().removeAttribute("results"); }
+
                             %>
 
                             <div class="steps">
@@ -119,88 +119,16 @@
                                 </div>
                             </div>
 
-                            // Output format for non-ui requests requires paging parameters (not a DisplayTag table
-                            <logic:present name="results" scope="request">
-                                <div class="formwrap">
-                                    <span class="tl"></span>
-                                    <span class="tr"><span></span></span>
-                                    <div class="formcon">
-                                        <h2>Search results</h2>
-
-                                        <!-- Paging banner (DisplayTag-like) -->
-                                        <div class="paging">
-                                            <logic:greaterThan name="page" value="1">
-                                                <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
-                                                    Previous
-                                                </a>
-                                            </logic:greaterThan>
-
-                                            Page ${page}
-
-                                            <logic:equal name="hasNextPage" value="true">
-                                                <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
-                                                    Next
-                                                </a>
-                                            </logic:equal>
-                                        </div>
-
-                                        <div class="result">
-                                            <!-- Table structure mimics DisplayTag output -->
-                                            <table id="result" class="displaytag">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Case number</th>
-                                                        <th>Title</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <logic:iterate id="row" name="results">
-                                                        <tr>
-                                                            <td>
-                                                                <a href="getDetail.do?case_id=<bean:write name='row' property='case_no'/>">
-                                                                    <bean:write name="row" property="case_no"/>
-                                                                </a>
-                                                            </td>
-                                                            <td>
-                                                                <bean:write name="row" property="title1"/>
-                                                            </td>
-                                                        </tr>
-                                                    </logic:iterate>
-                                                </tbody>
-                                            </table>
-                                        </div>
-
-                                        <!-- Bottom paging (optional but matches DisplayTag feel) -->
-                                        <div class="paging">
-                                            <logic:greaterThan name="page" value="1">
-                                                <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
-                                                    Previous
-                                                </a>
-                                            </logic:greaterThan>
-
-                                            Page ${page}
-
-                                            <logic:equal name="hasNextPage" value="true">
-                                                <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
-                                                    Next
-                                                </a>
-                                            </logic:equal>
-                                        </div>
-
-                                    </div>
-                                </div>
-                            </logic:present>
-
-                            <!-- Request-scoped results (API/bot users) -->
-                            <logic:present name="results" scope="request">
+                            <!-- Session-scoped results (UI paging) -->
+                            <logic:present name="results" scope="session">
                                 <div class="formwrap">
                                     <span class="tl"></span>
                                     <span class="tr"><span></span></span>
                                     <div class="formcon">
                                         <h2>Search results</h2>
                                         <div class="result">
-                                            <display:table id="result" name="requestScope.results" requestURI="/search.do"
-                                                           pagesize="5" sort="list">
+                                            <display:table id="result" name="sessionScope.results" requestURI="/search.do"
+                                                           pagesize="15" sort="list">
                                                 <display:setProperty
                                                         name="paging.banner.placement">top</display:setProperty>
                                                 <display:column property="case_no" title="Case number" paramId="case_id"
@@ -211,6 +139,82 @@
                                     </div>
                                 </div>
                             </logic:present>
+
+                            <!-- Request-scoped results (API/bot users) -->
+
+
+<logic:present name="results" scope="request">
+    <div class="formwrap">
+        <span class="tl"></span>
+        <span class="tr"><span></span></span>
+        <div class="formcon">
+            <h2>Search results</h2>
+
+            <!-- Paging banner (DisplayTag-like) -->
+            <div class="paging">
+                <logic:greaterThan name="page" value="1">
+                    <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
+                        Previous
+                    </a>
+                </logic:greaterThan>
+
+                Page ${page}
+
+                <logic:equal name="hasNextPage" value="true">
+                    <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
+                        Next
+                    </a>
+                </logic:equal>
+            </div>
+
+            <div class="result">
+                <!-- Table structure mimics DisplayTag output -->
+                <table id="result" class="displaytag">
+                    <thead>
+                        <tr>
+                            <th>Case number</th>
+                            <th>Title</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <logic:iterate id="row" name="results">
+                            <tr>
+                                <td>
+                                    <a href="getDetail.do?case_id=<bean:write name='row' property='case_no'/>">
+                                        <bean:write name="row" property="case_no"/>
+                                    </a>
+                                </td>
+                                <td>
+                                    <bean:write name="row" property="title1"/>
+                                </td>
+                            </tr>
+                        </logic:iterate>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Bottom paging (optional but matches DisplayTag feel) -->
+            <div class="paging">
+                <logic:greaterThan name="page" value="1">
+                    <a href="search.do?search=${param.search}&page=${page - 1}&pageSize=${pageSize}">
+                        Previous
+                    </a>
+                </logic:greaterThan>
+
+                Page ${page}
+
+                <logic:equal name="hasNextPage" value="true">
+                    <a href="search.do?search=${param.search}&page=${page + 1}&pageSize=${pageSize}">
+                        Next
+                    </a>
+                </logic:equal>
+            </div>
+
+        </div>
+    </div>
+</logic:present>
+
+
 
                             <div class="submitc">
                                 <div class="function previous">


### PR DESCRIPTION
Amend output for non-ui searches so that paging is handled at the database level and not at the session memory level
Replicate html output as close as possible to that of the UI searches which uses a struts table component to handle the paging from session memory