### PR TITLE
RST-8491: post migration improvements (#153)

### DIFF
--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -71,6 +71,7 @@ check_redirect "Legacy search action redirects"  "/search.do?search=a"          
 check_redirect "Legacy case detail redirects"    "/getDetail.do?case_id=DOES-NOT-EXIST" "/case/DOES-NOT-EXIST"
 check_redirect "Legacy admin login redirects"    "/loginform.do"                        "/admin/login"
 check_redirect "Legacy admin dataDump redirects"   "/dumpData.do"                       "/admin/import"
+check_redirect "Legacy jsessionid URL redirects"    "/getDetail.do;jsessionid=0E3FBB1014815D2F27D5E83607FD44D1?case_id=DOES-NOT-EXIST" "/case/DOES-NOT-EXIST"
 
 echo
 if [ "$FAILED" -ne 0 ]; then

--- a/src/main/java/uk/gov/moj/cact/config/JsessionIdUriFilter.java
+++ b/src/main/java/uk/gov/moj/cact/config/JsessionIdUriFilter.java
@@ -1,0 +1,62 @@
+package uk.gov.moj.cact.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JsessionIdUriFilter extends OncePerRequestFilter {
+
+    private static final Pattern JSESSIONID =
+            Pattern.compile(";jsessionid=[^;/?]*", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+        Matcher matcher = JSESSIONID.matcher(uri);
+
+        if (!matcher.find()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        chain.doFilter(new CleanUriRequest(request, matcher.replaceAll("")), response);
+    }
+
+    /** Presents the request with the jsessionid removed from its URI. */
+    private static final class CleanUriRequest extends HttpServletRequestWrapper {
+
+        private final String cleanUri;
+
+        CleanUriRequest(HttpServletRequest request, String cleanUri) {
+            super(request);
+            this.cleanUri = cleanUri;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return cleanUri;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            String scheme = getScheme();
+            int port = getServerPort();
+            StringBuffer url = new StringBuffer(scheme).append("://").append(getServerName());
+            boolean defaultPort = ("http".equals(scheme) && port == 80)
+                    || ("https".equals(scheme) && port == 443);
+            if (!defaultPort) {
+                url.append(':').append(port);
+            }
+            return url.append(cleanUri);
+        }
+    }
+}

--- a/src/main/java/uk/gov/moj/cact/config/WebConfig.java
+++ b/src/main/java/uk/gov/moj/cact/config/WebConfig.java
@@ -4,11 +4,20 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import uk.gov.moj.cact.monitoring.IpRateLimitFilter;
 
 @Configuration
 @EnableConfigurationProperties(RateLimitProperties.class)
 public class WebConfig {
+
+    @Bean
+    public FilterRegistrationBean<JsessionIdUriFilter> jsessionIdUriFilter() {
+        FilterRegistrationBean<JsessionIdUriFilter> registration = new FilterRegistrationBean<>(new JsessionIdUriFilter());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        registration.addUrlPatterns("/*");
+        return registration;
+    }
 
     @Bean
     public FilterRegistrationBean<IpRateLimitFilter> ipRateLimitFilter(RateLimitProperties properties) {

--- a/src/main/java/uk/gov/moj/cact/controller/SearchController.java
+++ b/src/main/java/uk/gov/moj/cact/controller/SearchController.java
@@ -137,21 +137,25 @@ public class SearchController {
     }
 
     private static int parsePage(String pageParam) {
-        if (pageParam != null) {
-            try {
-                return Math.max(Integer.parseInt(pageParam), 1);
-            } catch (NumberFormatException ignored) {
-                // fall through to default, as legacy did
-            }
+        if (pageParam == null || pageParam.isBlank()) {
+            return 1;
         }
-        return 1;
+        try {
+            return Math.max(Integer.parseInt(pageParam.trim()), 1);
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Ignoring unparseable page <{}>", pageParam);
+            return 1;
+        }
     }
 
     private static int parsePageSize(String sizeParam) {
+        if (sizeParam == null || sizeParam.isBlank()) {
+            return API_DEFAULT_PAGE_SIZE;
+        }
         try {
-            return Math.clamp(Integer.parseInt(sizeParam), 1, API_MAX_PAGE_SIZE);
-        } catch (RuntimeException e) {
-            LOGGER.warn("getPageSize Exception: ", e);
+            return Math.clamp(Integer.parseInt(sizeParam.trim()), 1, API_MAX_PAGE_SIZE);
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Ignoring unparseable pageSize <{}>", sizeParam);
             return API_DEFAULT_PAGE_SIZE;
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,6 +28,7 @@ server:
   servlet:
     session:
       timeout: 15m
+      tracking-modes: cookie
 
 management:
   endpoints:

--- a/src/test/java/uk/gov/moj/cact/config/JsessionIdUriFilterTest.java
+++ b/src/test/java/uk/gov/moj/cact/config/JsessionIdUriFilterTest.java
@@ -1,0 +1,73 @@
+package uk.gov.moj.cact.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsessionIdUriFilterTest {
+
+    private final JsessionIdUriFilter filter = new JsessionIdUriFilter();
+
+    /** The URI the application code (and Spring Security's firewall) will see. */
+    private String uriSeenDownstream(String requestUri) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+        request.setRequestURI(requestUri);
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        return ((HttpServletRequest) chain.getRequest()).getRequestURI();
+    }
+
+    @Test
+    void shouldStripJsessionIdFromLegacyDetailUrl() throws Exception {
+        assertEquals("/getDetail.do",
+                uriSeenDownstream("/getDetail.do;jsessionid=0E3FBB1014815D2F27D5E83607FD44D1"));
+    }
+
+    @Test
+    void shouldStripJsessionIdRegardlessOfCase() throws Exception {
+        assertEquals("/search.do", uriSeenDownstream("/search.do;JSESSIONID=ABC123"));
+        assertEquals("/search.do", uriSeenDownstream("/search.do;JSessionId=ABC123"));
+    }
+
+    @Test
+    void shouldLeaveOrdinaryUrlsUntouched() throws Exception {
+        assertEquals("/case/CA-2025-001011", uriSeenDownstream("/case/CA-2025-001011"));
+        assertEquals("/search", uriSeenDownstream("/search"));
+    }
+
+
+    // Only the session id is removed. Any other path parameter stays
+    @Test
+    void shouldNotStripOtherPathParameters() throws Exception {
+        assertEquals("/search.do;foo=bar", uriSeenDownstream("/search.do;foo=bar"));
+        assertEquals("/search.do;evil=1",
+                uriSeenDownstream("/search.do;jsessionid=ABC123;evil=1"));
+    }
+
+    @Test
+    void shouldStripJsessionIdMidPath() throws Exception {
+        assertEquals("/listing_calendar/search.jsp",
+                uriSeenDownstream("/listing_calendar;jsessionid=ABC123/search.jsp"));
+    }
+
+    @Test
+    void shouldRemoveJsessionIdFromRequestUrlToo() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/getDetail.do");
+        request.setRequestURI("/getDetail.do;jsessionid=ABC123");
+        request.setServerName("casetracker.justice.gov.uk");
+        request.setScheme("https");
+        request.setServerPort(443);
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+        assertEquals("https://casetracker.justice.gov.uk/getDetail.do",
+                ((HttpServletRequest) chain.getRequest()).getRequestURL().toString());
+    }
+}


### PR DESCRIPTION
* Reducing the logging noise when users dont provide the page number

* stripping the jsession from the url so it can me mapped to the correct page